### PR TITLE
Add basic scripts, cita-secp256k1, v0.22.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 homebrew-cita
 =============
 
+More details at [CITAHub Docs][1].
+
 ## Installation
 ```
 brew tap cryptape/cita
@@ -27,7 +29,7 @@ Click docker icon and share `/usr/local/Cellar/cita`.
 ### Create Chain
 
 ```
-$ cita create --chain_name "cita_block_chain" --super_admin "0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523" --nodes "127.0.0.1:4000,127.0.0.1:4001,127.0.0.1:4002,127.0.0.1:4003"
+$ cita create --chain_name "test-chain" --super_admin "0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523" --nodes "127.0.0.1:4000,127.0.0.1:4001,127.0.0.1:4002,127.0.0.1:4003"
 ```
 
 ### Setup Chain
@@ -64,7 +66,7 @@ _Here are some default sets, you can reset them on your own:_
 
 ```
 $ cita port 42:42
-# The docker port is `1337:1337` by default, if you need to, use this._
+# The docker port is `1337:1337` by default, if you need to, use this.
 ```
 
 ## Contributing
@@ -77,4 +79,4 @@ Please check [cryptape/cita][1] for more details.
 
 [Apache](/LICENSE)
 
-[1]: https://github.com/cryptape/cita
+[1]: https://docs.citahub.com/en-US/welcome

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+homebrew-cita
+=============
+
+## Installation
+```
+brew tap cryptape/cita
+```
+
+By default, binaries installed by cita will be placed into:
+
+```
+/usr/local/Cellar/cita/0.22.0
+```
+
+Run `cita help` for more detailed information.
+
+### Install docker
+```
+brew cask install docker
+```
+
+Click docker icon and share `/usr/local/Cellar/cita`.
+
+
+## Getting-Started
+
+### Create Chain
+
+```
+$ cita create --chain_name "cita_block_chain" --super_admin "0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523" --nodes "127.0.0.1:4000,127.0.0.1:4001,127.0.0.1:4002,127.0.0.1:4003"
+```
+
+### Setup Chain
+
+```
+$ cita setup test-chain/0
+```
+
+### Start Chain
+```
+$ cita start test-chain/0
+```
+
+### Stop Chain
+```
+$ cita stop test-chain/0
+```
+
+### Usages
+```
+$ cita
+Usage: cita <command> <node> [options]
+where <command> is one of the following:
+    { help | create | port | setup | start | stop | restart
+      ping | top | backup | clean | logs | logrotate }
+Run `cita help` for more detailed information.
+```
+
+## Presets
+
+_Here are some default sets, you can reset them on your own:_
+
+### Set Port
+
+```
+$ cita port 42:42
+# The docker port is `1337:1337` by default, if you need to, use this._
+```
+
+## Contributing
+
+CITA is still in active development. Building a blockchain platform is a huge task, we need your help. Any contribution is welcome.
+
+Please check [cryptape/cita][1] for more details.
+
+## License
+
+[Apache](/LICENSE)
+
+[1]: https://github.com/cryptape/cita

--- a/cita.rb
+++ b/cita.rb
@@ -1,0 +1,44 @@
+# CITA Formula
+class Cita < Formula
+  desc "A high performance blockchain for enterprise users."
+  homepage "https://github.com/cryptape/cita"
+
+  version "0.22.0"
+  url "https://github.com/cryptape/cita/releases/download/v0.22.0/cita_secp256k1_sha3.tar.gz"
+  sha256 "3f28abc41f98b4e2dc5122ad72d8032a1fb09751d148ab6483e9c2e50af7800d"
+  resource "cita" do
+    url "https://github.com/cryptape/cita.git",
+        :branch => "develop"
+    # Completing at v0.23
+    # :tag => ""
+    # :revision => ""
+  end
+
+  def install
+    libexec.install Dir["*"]
+
+    resource("cita").stage do
+      system  "cp", "-r", "env.sh", "#{libexec}/bin/cita-env"
+      system  "cp", "-r", "scripts/cita", "#{libexec}/bin/cita"
+      system  "cp", "-r", "scripts/cita_config.sh", "#{libexec}/bin/cita-config"
+    end
+
+    bin.install_symlink Dir["#{libexec}/bin/cita"]
+    bin.install_symlink Dir["#{libexec}/bin/cita-env"]
+    bin.install_symlink Dir["#{libexec}/bin/cita-config"]
+  end
+
+  def caveats; <<~EOS
+     By default, binaries installed by cita will be placed into:
+
+     #{libexec}
+
+     Usage: cita_commander <command> <node> [options]
+     where <command> is one of the following:
+         { help | create | port | setup | start | stop | restart
+           ping | top | backup | clean | logs | logrotate }
+     Run `cita help` for more detailed information.
+     happy hacking!
+  EOS
+  end
+end


### PR DESCRIPTION
The `cita.rb` formula has to depend on the latest `env.sh` which replacing

```shell
SOURCE_DIR="$(cd $(dirname "$0") && pwd -P)"
```

to

```shell
if [ `uname` == 'Darwin' ]; then
     SOURCE_DIR="$(dirname $(realpath $0))"
 else
     SOURCE_DIR="$(dirname $(readlink -f $0))"
fi
``` 

Because `pwd -P` can not handle symlinks in `/usr/local/bin`.