### PR TITLE
slim install script

### DIFF
--- a/cita.rb
+++ b/cita.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # CITA Formula
 class Cita < Formula
   desc "A high performance blockchain for enterprise users."
@@ -7,18 +8,14 @@ class Cita < Formula
   url "https://github.com/cryptape/cita/releases/download/v0.24.0/cita_secp256k1_sha3.tar.gz"
   sha256 "05dd4cea809e2f10c85b1a798e636d595968d4bea4e969a7be15cf89542352c2"
   resource "cita" do
-    url "https://github.com/cryptape/cita.git",
-        :tag => "v0.24.0"
-    # :revision => ""
+    url "https://raw.githubusercontent.com/cryptape/cita/v0.24.0/env.sh"
+    sha256 "0fb0ef52141c3bdb6ffba77c86f037e98cda599c06aadd2e8a7b79799352d833"
   end
 
   def install
     libexec.install Dir["*"]
-
     resource("cita").stage do
-      system  "cp", "-r", "env.sh", "#{libexec}/bin/cita-env"
-      system  "cp", "-r", "scripts/cita", "#{libexec}/bin/cita"
-      system  "cp", "-r", "scripts/cita_config.sh", "#{libexec}/bin/cita-config"
+      system  "cp", "-r", "./env.sh", "#{libexec}/bin/cita-env"
     end
 
     bin.install_symlink Dir["#{libexec}/bin/cita"]
@@ -36,7 +33,8 @@ class Cita < Formula
          { help | create | port | setup | start | stop | restart
            ping | top | backup | clean | logs | logrotate }
      Run `cita help` for more detailed information.
-     happy hacking!
+
+     happy hacking!!! 🧙
   EOS
   end
 end


### PR DESCRIPTION
After `v0.23.0`, no need to clone the whole `cryptape/cita` any more~

just clone the [env.sh][1] and `cita` will run well. 🍻

here is the test print:

```
 𝝺 brew install cita.rb 
==> Downloading https://github.com/cryptape/cita/releases/download/v0.24.0/cita_secp256k1_sha3.tar.gz
Already downloaded: /Users/mercury/Library/Caches/Homebrew/downloads/788d68811db6099adb3317d71e3d67053f190558d74895657d0cb71afe279cb3--cita_secp256k1_sha3.tar.gz
==> Downloading https://raw.githubusercontent.com/cryptape/cita/v0.24.0/env.sh
Already downloaded: /Users/mercury/Library/Caches/Homebrew/downloads/e5e1f75a8944839ac1e353445d8d6703e7577f5a1e1a04223b746765eacb3941--env.sh
==> cp -r ./env.sh /usr/local/Cellar/cita/0.24.0/libexec/bin/cita-env
==> Caveats
By default, binaries installed by cita will be placed into:

/usr/local/opt/cita/libexec

Usage: cita_commander <command> <node> [options]
where <command> is one of the following:
    { help | create | port | setup | start | stop | restart
      ping | top | backup | clean | logs | logrotate }
Run `cita help` for more detailed information.

happy hacking!!! 🧙
==> Summary
🍺  /usr/local/Cellar/cita/0.24.0: 217 files, 132.5MB, built in 8 seconds

 𝝺 cita help
Start docker container cita_run_container ...
4aa07b79bfcf6d05f6a6ae368f400f25a1b5d4df6c7af587ee2a6ab5dbd33c58
Usage: cita <command> <node> [options]
This is the primary script for controlling the cita node.
 INFORMATIONAL COMMANDS
    help
        You are here.
 BUILDING COMMANDS
    create <config>
        Creates blockchains according to the following config,
        use "cita create -h" to get more information.
        "cita-config" has the same function.
    append <config>
        Append a node into an existed chain,
        use "cita append -h" to get more information.
        "cita-config" has the same function.
    port <ports>
        Sets docker port, for example: "cita port 1337:1337 1338:1338",
        expose docker port 1337 and 1338.
 SERVICE CONTROL COMMANDS
    setup <node>
        Ensuring the required runtime environment for cita node, like
        RabbitMQ service. You should run this command at the first time
        of running cita node.
    start <node>
        Starts the cita node in the background. If the node is already
        started, you will get the message "Node is already running!" If the
        node is not already running, no output will be given.
    stop <node> [debug] [mock]
        Stops the running cita node. Prints "ok" when successful.  When
        the node is already stopped or not responding, prints:
        "Node 'NODE_NAME' not responding to pings."
    restart <node>
        Stops and then starts the running cita node. Prints "ok"
        when successful.  When the node is already stopped or not
        responding, prints: "Node 'NODE_NAME' not responding to
        pings."
 DIAGNOSTIC COMMANDS
    ping <node>
        Checks that the cita node is running. Prints "pong" when
        successful.  When the node is stopped or not responding, prints:
        "Node 'NODE_NAME' not responding to pings."
    top <node>
        Prints services processes information similar
        to the information provided by the `top` command.
    stat <node> (deprecated, use 'top' instead)
    logs <node> <service>
        Fetch the logs of the specified service.
 SCRIPTING COMMANDS
    backup <node>
        Backup the node's data and logs into backup directory, which actually
        copy that data and logs into backup directory. Prints the specified
        backup commands. When the node is running, prints:
        "Node is already running!"
    clean <node>
        Clean the node's data and logs, which actually move that data and logs
        into backup directory. Prints the specified backup commands. When the
        node is running, prints: "Node is already running!"
    logrotate <node>
        Archives the current node logs, starts fresh logs. Prints the archived
        logs path.
 𝝺 
```


[1]: https://raw.githubusercontent.com/cryptape/cita/v0.24.0/env.sh